### PR TITLE
Improve Progress Reporting

### DIFF
--- a/connectors/cosmos/connector.go
+++ b/connectors/cosmos/connector.go
@@ -219,6 +219,7 @@ func (cc *Connector) StartReadToChannel(flowId iface.FlowID, options iface.Conne
 	namespaces := make([]namespace, 0)
 
 	cc.restoreProgressDetails(tasks)
+	// reset doc counts for all namespaces to actual for more accurate progress reporting
 	cc.resetNsProgressEstimatedDocCounts()
 
 	if len(tasks) == 0 {

--- a/connectors/cosmos/connector.go
+++ b/connectors/cosmos/connector.go
@@ -362,7 +362,7 @@ func (cc *Connector) StartReadToChannel(flowId iface.FlowID, options iface.Conne
 					ns := iface.Namespace{Db: db, Col: col}
 
 					nsStatus := cc.status.ProgressMetrics.NamespaceProgress[ns]
-					cc.taskStartedProgressUpdate(nsStatus)
+					cc.taskStartedProgressUpdate(nsStatus, task.Id)
 
 					collection := cc.client.Database(db).Collection(col)
 					cursor, err := createFindQuery(cc.flowCtx, collection, task)
@@ -411,14 +411,14 @@ func (cc *Connector) StartReadToChannel(flowId iface.FlowID, options iface.Conne
 						readerProgress.tasksCompleted++ //XXX Should we do atomic add here as well, shared variable multiple threads
 
 						//update the progress after completing the task and create task metadata to pass to coordinator to persist
-						cc.taskDoneProgressUpdate(nsStatus)
+						cc.taskDoneProgressUpdate(nsStatus, task.Id)
 
 						slog.Debug(fmt.Sprintf("Done processing task: %v", task))
 						//notify the coordinator that the task is done from our side
 						taskData := iface.TaskDoneMeta{DocsCopied: docs}
 						cc.coord.NotifyTaskDone(cc.flowId, cc.id, task.Id, &taskData)
 						//send a barrier message to signal the end of the task
-						if cc.flowConnCapabilities.Resumability { //send only if the flow supports resumability otherwise who knows what will happen on the recieving side
+						if cc.flowConnCapabilities.Resumability { //send only if the flow supports resumability otherwise who knows what will happen on the receiving side
 							dataChannel <- iface.DataMessage{MutationType: iface.MutationType_Barrier, BarrierType: iface.BarrierType_TaskComplete, BarrierTaskId: (uint)(task.Id)}
 						}
 					}

--- a/connectors/cosmos/connector.go
+++ b/connectors/cosmos/connector.go
@@ -219,6 +219,7 @@ func (cc *Connector) StartReadToChannel(flowId iface.FlowID, options iface.Conne
 	namespaces := make([]namespace, 0)
 
 	cc.restoreProgressDetails(tasks)
+	cc.resetNsProgressEstimatedDocCounts()
 
 	if len(tasks) == 0 {
 		return errors.New("no tasks to copy")

--- a/connectors/cosmos/planner.go
+++ b/connectors/cosmos/planner.go
@@ -230,18 +230,18 @@ func (cc *Connector) parallelNamespaceTaskPreparer(countCheckChannel <-chan ifac
 					//send min and max tasks to finalized channel
 					minTask := cc.createReadPlanTaskForNs(nsTask)
 					minTask.Def.PartitionKey = cc.settings.partitionKey
-					minTask.Def.High = min //only setting the high boundary indicating that we want (-INF, min)
-					minTask.EstimatedDocCount = cc.settings.TargetDocCountPerPartition
+					minTask.Def.High = min        //only setting the high boundary indicating that we want (-INF, min)
+					minTask.EstimatedDocCount = 0 //we don't expect anything to be there
 
 					maxTask := cc.createReadPlanTaskForNs(nsTask)
 					maxTask.Def.PartitionKey = cc.settings.partitionKey
-					maxTask.Def.Low = max //only setting the low boundary indicating that we want (max, INF)
-					maxTask.EstimatedDocCount = cc.settings.TargetDocCountPerPartition
+					maxTask.Def.Low = max         //only setting the low boundary indicating that we want (max, INF)
+					maxTask.EstimatedDocCount = 0 //we don't expect anything to be there
 
 					finalTasksChannel <- minTask
 					finalTasksChannel <- maxTask
 
-					//send the tasks with approx bounaries downstream
+					//send the tasks with approx boundaries downstream
 					for i := 0; i < len(approxBounds)-1; i++ {
 						task := cc.createReadPlanTaskForNs(nsTask)
 						task.Def.PartitionKey = cc.settings.partitionKey

--- a/connectors/cosmos/util.go
+++ b/connectors/cosmos/util.go
@@ -219,6 +219,7 @@ func (cc *Connector) restoreProgressDetails(tasks []iface.ReadPlanTask) { //XXX:
 				TasksStarted:        0,
 				DocsCopied:          0,
 				EstimatedDocsCopied: 0,
+				ActiveTasksList:     make(map[iface.ReadPlanTaskID]bool),
 			}
 			cc.status.ProgressMetrics.NamespaceProgress[ns] = nsStatus
 		}
@@ -233,7 +234,6 @@ func (cc *Connector) restoreProgressDetails(tasks []iface.ReadPlanTask) { //XXX:
 			nsStatus.DocsCopied += task.DocsCopied
 
 			nsStatus.EstimatedDocsCopied += task.EstimatedDocCount
-			slog.Debug(fmt.Sprintf("totalDocsCopied: %v, ns docs copied: %v", cc.status.ProgressMetrics.NumDocsSynced, nsStatus.DocsCopied))
 		}
 	}
 	cc.status.ProgressMetrics.NumNamespaces = int64(len(cc.status.ProgressMetrics.NamespaceProgress))
@@ -250,21 +250,35 @@ func (cc *Connector) restoreProgressDetails(tasks []iface.ReadPlanTask) { //XXX:
 }
 
 // Updates the progress metrics once a task has been started
-func (cc *Connector) taskStartedProgressUpdate(nsStatus *iface.NamespaceStatus) {
+func (cc *Connector) taskStartedProgressUpdate(nsStatus *iface.NamespaceStatus, taskId iface.ReadPlanTaskID) {
 	cc.muProgressMetrics.Lock()
+	nsStatus.ActiveTasksList[taskId] = true
 	cc.status.ProgressMetrics.TasksStarted++
 	nsStatus.TasksStarted++
 	cc.muProgressMetrics.Unlock()
 }
 
 // Updates the progress metrics once a task has been completed
-func (cc *Connector) taskDoneProgressUpdate(nsStatus *iface.NamespaceStatus) {
+func (cc *Connector) taskDoneProgressUpdate(nsStatus *iface.NamespaceStatus, taskId iface.ReadPlanTaskID) {
 	cc.muProgressMetrics.Lock()
 	//update progress counters: num tasks completed
 	cc.status.ProgressMetrics.TasksCompleted++
 	nsStatus.TasksCompleted++
+
+	//go through all the tasks
+	// - mark ours as completed
+	// - calculate the approximate number of docs copied based on per-task estimates
+	approxDocsCopied := int64(0)
+	for i, task := range nsStatus.Tasks {
+		if task.Id == taskId {
+			nsStatus.Tasks[i].Status = iface.ReadPlanTaskStatus_Completed
+		}
+		if task.Status == iface.ReadPlanTaskStatus_Completed {
+			approxDocsCopied += task.EstimatedDocCount
+		}
+	}
 	//update the estimated docs copied count for the namespace to keep percentage proportional
-	nsStatus.EstimatedDocsCopied = int64(math.Max(float64(nsStatus.EstimatedDocsCopied), float64(nsStatus.TasksCompleted*nsStatus.Tasks[0].EstimatedDocCount)))
+	nsStatus.EstimatedDocsCopied = int64(math.Max(float64(nsStatus.EstimatedDocsCopied), float64(approxDocsCopied)))
 	//check if namespace has been completed
 	if nsStatus.TasksCompleted == int64(len(nsStatus.Tasks)) {
 		cc.status.ProgressMetrics.NumNamespacesCompleted++
@@ -272,6 +286,8 @@ func (cc *Connector) taskDoneProgressUpdate(nsStatus *iface.NamespaceStatus) {
 	//decrement the tasks started counter
 	cc.status.ProgressMetrics.TasksStarted--
 	nsStatus.TasksStarted--
+	//remove the task from the active tasks list
+	delete(nsStatus.ActiveTasksList, taskId)
 	cc.muProgressMetrics.Unlock()
 }
 

--- a/protocol/iface/connector.go
+++ b/protocol/iface/connector.go
@@ -89,13 +89,14 @@ type Namespace struct {
 }
 
 type NamespaceStatus struct {
-	EstimatedDocCount   int64          // Estimated number of documents in the namespace
-	Throughput          float64        // Throughput in operations per second
-	Tasks               []ReadPlanTask //all the tasks for the namespace
-	TasksCompleted      int64          //number of tasks completed
-	TasksStarted        int64          //number of tasks started
-	DocsCopied          int64          //number of documents copied
-	EstimatedDocsCopied int64          //this is for calculating percentage complete based on approximate number of docs per task, not actual number of docs copied
+	EstimatedDocCount   int64                   // Estimated number of documents in the namespace
+	Throughput          float64                 // Throughput in operations per second
+	Tasks               []ReadPlanTask          //all the tasks for the namespace
+	TasksCompleted      int64                   //number of tasks completed
+	TasksStarted        int64                   //number of tasks started
+	DocsCopied          int64                   //number of documents copied
+	EstimatedDocsCopied int64                   //this is for calculating percentage complete based on approximate number of docs per task, not actual number of docs copied
+	ActiveTasksList     map[ReadPlanTaskID]bool //map of active task ids
 }
 
 // Pass options to use to the connector

--- a/protocol/iface/coordinator.go
+++ b/protocol/iface/coordinator.go
@@ -86,7 +86,7 @@ type CoordinatorIConnectorSignal interface {
 	NotifyDone(flowId FlowID, conn ConnectorID) error
 
 	// Done event for a task (for a connector to announce that they finished a task)
-	// Accepts the opional taskData parameter which is a connector-specific task data to be persisted along the task
+	// Accepts the optional taskData parameter which is a connector-specific task data to be persisted along the task
 	NotifyTaskDone(flowId FlowID, conn ConnectorID, taskId ReadPlanTaskID, taskData *TaskDoneMeta) error
 
 	// Planning completion event (for a connector to share the read plan)


### PR DESCRIPTION
Make progress account for min and max tasks that have 0 estimated document count
Also get the most up-to-date counts from the source for collection counts for reporting