### PR TITLE
Best effort attempt to batch writes.

### DIFF
--- a/connectors/cosmos/connector.go
+++ b/connectors/cosmos/connector.go
@@ -465,7 +465,7 @@ func (cc *Connector) StartWriteFromChannel(flowId iface.FlowID, dataChannelId if
 	writerProgress.dataMessages.Store(0)
 
 	// create a batch assembly for initializing/starting parallel writers
-	flowParallelWriter := mongoconn.NewParallelWriter(cc.FlowCtx, cc, cc.settings.NumParallelWriters)
+	flowParallelWriter := mongoconn.NewParallelWriter(cc.FlowCtx, cc, cc.settings.NumParallelWriters, cc.settings.WriterMaxBatchSize)
 	flowParallelWriter.Start()
 
 	// start printing progress

--- a/connectors/mongo/connector.go
+++ b/connectors/mongo/connector.go
@@ -482,7 +482,7 @@ func (mc *Connector) StartWriteFromChannel(flowId iface.FlowID, dataChannelId if
 	writerProgress.dataMessages.Store(0)
 
 	// create a batch assembly
-	flowParallelWriter := NewParallelWriter(mc.FlowCtx, mc, mc.Settings.NumParallelWriters)
+	flowParallelWriter := NewParallelWriter(mc.FlowCtx, mc, mc.Settings.NumParallelWriters, mc.Settings.WriterMaxBatchSize)
 	flowParallelWriter.Start()
 
 	// start printing progress


### PR DESCRIPTION
Attempts to batch the writes in a best effort manner. It will break up the batches if the assumptions don't hold.

1. Parallel Writer: Will attempt to batch up to the configured max, but break batches up if the db/collections are different or if an insert batch type is seen. Will break a batch upon encountering a barrier and also if the channel is empty.

2. ProcessDataMessages: Assumes same db/collection. Breaks batches up if it sees an insert batch type (does not assume it is at the end, also does not assume there are not more than the max number of configured messages). Also, keeps track of the latest update for a particular document in the same batch so it can keep only the latest update. Falls back to original code for processing an insert batch type.

Q: Does it make sense to break the batch upon encountering a barrier or only if it is the "last" one or something else?