### PR TITLE
[fix] Allow graceful shutdown on ctrl C

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,32 +6,15 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"os/signal"
-	"syscall"
 
 	dsync "github.com/adiom-data/dsync/internal/app"
 )
 
 func main() {
-
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGPIPE)
-	cancellableCtx, cancelApp := context.WithCancel(context.Background())
-
-	go func() {
-		for s := range sigChan {
-			if s != syscall.SIGPIPE {
-				cancelApp()
-				break
-			}
-		}
-	}()
-
 	app := dsync.NewApp()
-	err := app.RunContext(cancellableCtx, os.Args)
+	err := app.Run(os.Args)
 	if err != nil {
 		fmt.Printf("dsync exited with error: %v\n", err)
 	} else {

--- a/runners/local/runner.go
+++ b/runners/local/runner.go
@@ -387,6 +387,11 @@ func (r *RunnerLocal) Run() error {
 	return nil
 }
 
+func (r *RunnerLocal) GracefulShutdown() {
+	slog.Debug("RunnerLocal GracefulShutdown")
+	r.src.Teardown()
+}
+
 func (r *RunnerLocal) Teardown() {
 	slog.Debug("RunnerLocal Teardown")
 

--- a/statestores/mongo/statestore.go
+++ b/statestores/mongo/statestore.go
@@ -95,7 +95,7 @@ func (s *StateStore) Setup(ctx context.Context) error {
 func (s *StateStore) Teardown() {
 	if s.client != nil {
 		if err := s.client.Disconnect(s.ctx); err != nil {
-			panic(err)
+			slog.Warn(fmt.Sprintf("Failed to disconnect from MongoDb: %v", err))
 		}
 	}
 }


### PR DESCRIPTION
This is a quick fix by
1) Moving the signal handling into app.go, where we actually have access to things like the runner. In main.go we don't have many levers without significant refactoring.

2) Adding a graceful shutdown method to the local runner (not currently reflected in the interface, but we can consider adding it). This method just attempts to shutdown the source, which if it finishes causes a flow to be done.
