### PR TITLE
[fix] Blocking barrier to ensure initial sync completes first.

### DIFF
--- a/connectors/cosmos/connector.go
+++ b/connectors/cosmos/connector.go
@@ -424,6 +424,11 @@ func (cc *Connector) StartReadToChannel(flowId iface.FlowID, options iface.Conne
 
 		//wait for all copiers to finish
 		wg.Wait()
+
+		dataChannel <- iface.DataMessage{
+			MutationType: iface.MutationType_Barrier,
+			BarrierType:  iface.BarrierType_Block,
+		}
 	}()
 
 	// wait for both the change stream reader and the initial sync to finish

--- a/connectors/mongo/connector.go
+++ b/connectors/mongo/connector.go
@@ -441,6 +441,11 @@ func (mc *Connector) StartReadToChannel(flowId iface.FlowID, options iface.Conne
 
 		//wait for all copiers to finish
 		wg.Wait()
+
+		dataChannel <- iface.DataMessage{
+			MutationType: iface.MutationType_Barrier,
+			BarrierType:  iface.BarrierType_Block,
+		}
 	}()
 
 	// wait for both the change stream reader and the initial sync to finish

--- a/connectors/testconn/connector.go
+++ b/connectors/testconn/connector.go
@@ -231,6 +231,11 @@ func (c *connector) StartReadToChannel(flowId iface.FlowID, options iface.Connec
 					Collection: col,
 				},
 			}
+
+			channel <- iface.DataMessage{
+				MutationType: iface.MutationType_Barrier,
+				BarrierType:  iface.BarrierType_Block,
+			}
 		Loop:
 			for {
 				for _, splitted := range allSplitted {

--- a/protocol/iface/transport.go
+++ b/protocol/iface/transport.go
@@ -46,6 +46,7 @@ const (
 	BarrierType_Reserved = iota
 	BarrierType_TaskComplete
 	BarrierType_CdcResumeTokenUpdate
+	BarrierType_Block
 )
 
 // Special barrier message used for task completion signals over the data channel


### PR DESCRIPTION
Adds a blocking barrier, that a writer should interpret as everything before this must be processed before proceeding.

This is to fix the initial sync must complete before any CDC events are reflected. In the future we may change how this is handled, but this at least will fix the urgent correctness issue.
