### PR TITLE
[feat] Adding simple tail verification

### DIFF
--- a/connectors/mongo/conn.go
+++ b/connectors/mongo/conn.go
@@ -506,7 +506,7 @@ func convertChangeStreamEventToUpdate(change bson.M) (*adiomv1.Update, error) {
 			Type: adiomv1.UpdateType_UPDATE_TYPE_INSERT,
 			Data: fullDocumentRaw,
 		}
-	case "update":
+	case "update", "replace":
 		// get the id of the document that was changed
 		id := change["documentKey"].(bson.M)["_id"]
 		// convert id to raw bson


### PR DESCRIPTION
This could be a separate command, but for now just an option. This works by tailing both sides, and comparing only difference older than <configured>. This means if there is an item thats being rapidly updated forever, we don't compare those.

Also fixed issue with mongo connector not supporting "replace"