### PR TITLE
Remove sort in the find query for reading tasks

### DIFF
--- a/connectors/mongo/conn.go
+++ b/connectors/mongo/conn.go
@@ -334,7 +334,7 @@ func (c *conn) ListData(ctx context.Context, r *connect.Request[adiomv1.ListData
 		c.buffersMutex.Unlock()
 
 		filter := createFindFilterFromCursor(r.Msg.GetPartition().GetCursor())
-		cursor, err := collection.Find(ctx, filter, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
+		cursor, err := collection.Find(ctx, filter)
 		if err != nil {
 			if !errors.Is(err, context.Canceled) {
 				slog.Error(fmt.Sprintf("Failed to find documents: %v", err))


### PR DESCRIPTION
This is a bug in Cosmos DB related to the read query result batch size. It affects queries that match a large block of data and require merge sorting across partitions: e.g. find({_id:{$gte: X, $lt: Y}}).sort({_id:1}).
The batch size is adjusted dynamically by the Cosmos DB server. However, in the presence of sort() that requires merging results from individual partitions, the final batch size is proportional to the number of partitions. Removing the sort eliminates the problem.
We added the sort as a precaution to maintain the document ordering during the initial data copy, but we believe it’s safe to remove. We informed the Cosmos DB team of the issue and we will reconsider reintroducing sort when the underlying issue is fixed.