### PR TITLE
add ability to create grpc server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22.0
 
 require (
 	connectrpc.com/connect v1.17.0
+	connectrpc.com/grpcreflect v1.2.0
 	github.com/aws/aws-sdk-go-v2 v1.32.4
 	github.com/aws/aws-sdk-go-v2/config v1.28.3
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.15.12

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 connectrpc.com/connect v1.17.0 h1:W0ZqMhtVzn9Zhn2yATuUokDLO5N+gIuBWMOnsQrfmZk=
 connectrpc.com/connect v1.17.0/go.mod h1:0292hj1rnx8oFrStN7cB4jjVBeqs+Yx5yDIC2prWDO8=
+connectrpc.com/grpcreflect v1.2.0 h1:Q6og1S7HinmtbEuBvARLNwYmTbhEGRpHDhqrPNlmK+U=
+connectrpc.com/grpcreflect v1.2.0/go.mod h1:nwSOKmE8nU5u/CidgHtPYk1PFI3U9ignz7iDMxOYkSY=
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -55,6 +55,7 @@ func NewApp() *cli.App {
 		Action:    runDsync,
 		Commands: []*cli.Command{
 			verifyCommand,
+			serveCommand,
 		},
 	}
 

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -1,0 +1,127 @@
+package dsync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"connectrpc.com/grpcreflect"
+	"github.com/adiom-data/dsync/gen/adiom/v1/adiomv1connect"
+	"github.com/adiom-data/dsync/internal/app/options"
+	"github.com/adiom-data/dsync/logger"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+	"golang.org/x/sync/errgroup"
+)
+
+var serveCommand *cli.Command = &cli.Command{
+	Name:   "serve",
+	Action: runServe,
+	Usage:  "dsync serve --address localhost:8088 [other-options] connector [connector-options]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "verbosity",
+			Usage: "DEBUG|INFO|WARN|ERROR",
+			Value: "INFO",
+		},
+		&cli.StringFlag{
+			Name:     "address",
+			Usage:    "host:port e.g. localhost:8080",
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:  "cert-file",
+			Usage: "Cerificate file",
+		},
+		&cli.StringFlag{
+			Name:  "key-file",
+			Usage: "Key file",
+		},
+	},
+}
+
+func runServe(c *cli.Context) error {
+	logger.Setup(logger.Options{Verbosity: c.String("verbosity")})
+
+	address := c.String("address")
+	certFile := c.String("cert-file")
+	keyFile := c.String("key-file")
+	clearText := false
+	if certFile == "" && keyFile == "" {
+		clearText = true
+	}
+
+	args := c.Args().Slice()
+	var connector adiomv1connect.ConnectorServiceHandler
+	registeredConnectors := options.GetRegisteredConnectors()
+	if len(args) < 1 {
+		return fmt.Errorf("missing target connector")
+	}
+	for _, registeredConnector := range registeredConnectors {
+		if registeredConnector.IsConnector(args[0]) {
+			if registeredConnector.Create != nil {
+				var err error
+				connector, _, err = registeredConnector.Create(args, options.AdditionalSettings{})
+				if err != nil {
+					return fmt.Errorf("error creating connector")
+				}
+			}
+		}
+	}
+	if connector == nil {
+		return fmt.Errorf("unable to create target connector")
+	}
+
+	reflector := grpcreflect.NewStaticReflector(adiomv1connect.ConnectorServiceName)
+	mux := http.NewServeMux()
+	path, serviceHandler := adiomv1connect.NewConnectorServiceHandler(connector)
+	mux.Handle(path, serviceHandler)
+	mux.Handle(grpcreflect.NewHandlerV1(reflector))
+	mux.Handle(grpcreflect.NewHandlerV1Alpha(reflector))
+	var handler http.Handler
+
+	if clearText {
+		handler = h2c.NewHandler(mux, &http2.Server{})
+	} else {
+		handler = mux
+	}
+
+	srv := http.Server{
+		Addr:    address,
+		Handler: handler,
+	}
+
+	var eg errgroup.Group
+	eg.Go(func() error {
+		if clearText {
+			slog.Info("Cleartext server.")
+			return srv.ListenAndServe()
+		} else {
+			return srv.ListenAndServeTLS(certFile, keyFile)
+		}
+	})
+
+	done := make(chan os.Signal, 1)
+	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+
+	eg.Go(func() error {
+		<-done
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
+		defer cancel()
+		return srv.Shutdown(ctx)
+	})
+
+	if err := eg.Wait(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		slog.Warn("Shutdown was not clean", "err", err)
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
So this allows us to run any of the local implementations as a standalone server, and then use another instance of dsync to connect to it.

e.g.

```
dsync serve --address localhost:8088 /dev/null
```

```
dsync /dev/random grpc://localhost:8088 --insecure
```