### PR TITLE
Query filter for initial sync in Mongo connector

### DIFF
--- a/connectors/mongo/conn.go
+++ b/connectors/mongo/conn.go
@@ -910,7 +910,7 @@ func NewConnWithClient(client *mongo.Client, settings ConnectorSettings) adiomv1
 	ctx, cancel := context.WithCancel(context.Background())
 	query, err := stringToQuery(settings.Query)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to parse query: %v", err))
+		slog.Error(fmt.Sprintf("Failed to parse query (%v): %v", settings.Query, err))
 	}
 	return &conn{
 		client:          client,

--- a/connectors/mongo/util.go
+++ b/connectors/mongo/util.go
@@ -193,3 +193,18 @@ func redactedSettings(s ConnectorSettings) ConnectorSettings {
 
 	return copy
 }
+
+func stringToQuery(queryStr string) (bson.D, error) {
+	if queryStr == "" {
+		return bson.D{}, nil
+	}
+
+	content := []byte(queryStr)
+
+	var query bson.D
+	err := bson.UnmarshalExtJSON(content, false, &query)
+	if err != nil {
+		return bson.D{}, fmt.Errorf("error parsing query as Extended JSON: %v", err)
+	}
+	return query, nil
+}

--- a/internal/app/options/connectorflags.go
+++ b/internal/app/options/connectorflags.go
@@ -414,6 +414,7 @@ func MongoFlags(settings *mongo.ConnectorSettings) []cli.Flag {
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:        "initial-sync-query",
 			Usage:       "query filter for the initial data copy (v2 Extended JSON)",
+			Aliases:     []string{"q"},
 			Required:    false,
 			Destination: &settings.Query,
 		}),

--- a/internal/app/options/connectorflags.go
+++ b/internal/app/options/connectorflags.go
@@ -411,6 +411,12 @@ func MongoFlags(settings *mongo.ConnectorSettings) []cli.Flag {
 			Destination: &settings.TargetDocCountPerPartition,
 			Value:       50 * 1000,
 		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:        "initial-sync-query",
+			Usage:       "query filter for the initial data copy (v2 Extended JSON)",
+			Required:    false,
+			Destination: &settings.Query,
+		}),
 	}
 }
 


### PR DESCRIPTION
New "-q" option for Mongo connector that accepts Extended JSON (just like mongodump)

The filtering is applied after read planning

Only impacts initial data copy. 