### PR TITLE
[fix] Issues with dynamodb streaming

### DIFF
--- a/connectors/dynamodb/stream/state.go
+++ b/connectors/dynamodb/stream/state.go
@@ -20,11 +20,11 @@ func NewStreamState(streamARN string) StreamState {
 
 func ShardIteratorInputFromState(state StreamState, after bool) []*dynamodbstreams.GetShardIteratorInput {
 	var res []*dynamodbstreams.GetShardIteratorInput
-	typ := types.ShardIteratorTypeAtSequenceNumber
-	if after {
-		typ = types.ShardIteratorTypeAfterSequenceNumber
-	}
 	for k, v := range state.ShardIDToSequenceNumber {
+		typ := types.ShardIteratorTypeAtSequenceNumber
+		if after {
+			typ = types.ShardIteratorTypeAfterSequenceNumber
+		}
 		var seqNum *string
 		if v != "" {
 			seqNum = aws.String(v)


### PR DESCRIPTION
Fix some issues with dynamodb connector on the streaming bit.
1. longer default skip empty
2. shard iterator initialization could use unintended type
3. for approx time if nothing found during the search we'll just default to empty which becomes TRIM_HORIZON (seems there was an issue with "after start sequence" number during investigations)