### PR TITLE
Support same connector on src and dst.

### DIFF
--- a/coordinators/simple/coordinator.go
+++ b/coordinators/simple/coordinator.go
@@ -70,10 +70,8 @@ func (c *Simple) addConnector(connector ConnectorDetailsWithEp) iface.ConnectorI
 
 	var cid iface.ConnectorID
 
-	// If details.Id is not empty, means that the connector is being re-registered
 	if connector.Details.Id != "" {
-		//TODO: check if the connector is already in the map - this would be an error
-		slog.Debug("Re-registering connector with ID: " + (string)(connector.Details.Id))
+		connector.Details.Id += "-" + iface.ConnectorID(connector.Details.Desc)
 		cid = connector.Details.Id
 	} else {
 		// we need to generate a new unique ID


### PR DESCRIPTION
So this solution just modifies the connector id so that they are forced to be different. It is a bit of a hacky workaround.

Trying to reuse the id is pretty involved due to the code having an assumption they are different in multiple places (much more involved change).