### PR TITLE
Add last read event time (for mongo)

### DIFF
--- a/connectors/common/base.go
+++ b/connectors/common/base.go
@@ -716,6 +716,8 @@ func (c *connector) StartReadToChannel(flowId iface.FlowID, options iface.Connec
 				c.resumeToken = msg.GetNextCursor()
 				c.resumeTokenMutex.Unlock()
 			}
+
+			c.progressTracker.UpdateChangeStreamLastTime(msg.GetTime().AsTime())
 		}
 		if res.Err() != nil {
 			if !errors.Is(res.Err(), context.Canceled) {

--- a/connectors/common/progress.go
+++ b/connectors/common/progress.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"math"
 	"sync"
+	"time"
 
 	"github.com/adiom-data/dsync/protocol/iface"
 )
@@ -171,6 +172,14 @@ func (pt *ProgressTracker) UpdateChangeStreamProgressTracking() {
 	pt.muProgressMetrics.Lock()
 	defer pt.muProgressMetrics.Unlock()
 	pt.status.ProgressMetrics.ChangeStreamEvents++
+}
+
+func (pt *ProgressTracker) UpdateChangeStreamLastTime(t time.Time) {
+	pt.muProgressMetrics.Lock()
+	defer pt.muProgressMetrics.Unlock()
+	if !t.IsZero() && t.After(pt.status.ProgressMetrics.LastChangeStreamTime) {
+		pt.status.ProgressMetrics.LastChangeStreamTime = t.UTC()
+	}
 }
 
 func (pt *ProgressTracker) UpdateWriteLSN(lsn int64) {

--- a/internal/app/progress.go
+++ b/internal/app/progress.go
@@ -131,6 +131,9 @@ func (tv *TViewDetails) GetStatusReport(runnerProgress runnerLocal.RunnerSyncPro
 		if runnerProgress.AdditionalStateInfo != "" {
 			headerString += "\n" + runnerProgress.AdditionalStateInfo
 		}
+		if !runnerProgress.ChangeStreamLastTime.IsZero() {
+			headerString += "\nLast Change Stream Read: " + runnerProgress.ChangeStreamLastTime.String()
+		}
 		header.SetText(headerString)
 
 		//set the indefinite progress bar

--- a/protocol/iface/connector.go
+++ b/protocol/iface/connector.go
@@ -7,6 +7,7 @@ package iface
 
 import (
 	"context"
+	"time"
 )
 
 type ConnectorType struct {
@@ -94,6 +95,8 @@ type ProgressMetrics struct {
 	//progress reporting attributes
 	NamespaceProgress map[Namespace]*NamespaceStatus //map key is namespace: "db.col"
 	Namespaces        []Namespace
+
+	LastChangeStreamTime time.Time
 }
 
 type Namespace struct {

--- a/runners/local/progress.go
+++ b/runners/local/progress.go
@@ -17,9 +17,10 @@ type RunnerSyncProgress struct {
 	SourceDescription      string
 	DestinationDescription string
 
-	StartTime time.Time // start of the sync process
-	CurrTime  time.Time // current time
-	SyncState string    // current state of the sync process
+	StartTime            time.Time // start of the sync process
+	CurrTime             time.Time // current time
+	ChangeStreamLastTime time.Time
+	SyncState            string // current state of the sync process
 
 	TotalNamespaces        int64 // total number of namespaces to sync
 	NumNamespacesCompleted int64 // number of namespaces completed
@@ -80,6 +81,7 @@ func (r *RunnerLocal) UpdateRunnerProgress() {
 	r.runnerProgress.AdditionalStateInfo = stateInfo
 
 	r.runnerProgress.CurrTime = time.Now()
+	r.runnerProgress.ChangeStreamLastTime = srcStatus.ProgressMetrics.LastChangeStreamTime
 	r.runnerProgress.TotalNamespaces = srcStatus.ProgressMetrics.NumNamespaces
 	r.runnerProgress.NumDocsSynced = srcStatus.ProgressMetrics.NumDocsSynced
 

--- a/static/index.html
+++ b/static/index.html
@@ -426,19 +426,19 @@
       }
 
       .table-row,
-      .table-row-3 {
+      .table-row-4 {
         display: grid;
         grid-template-columns: repeat(6, minmax(6rem, 1fr));
         justify-content: space-between;
         border-top: 1px solid rgb(var(--separator));
       }
 
-      .table-row-3 {
-        grid-template-columns: repeat(3, minmax(9rem, 1fr));
+      .table-row-4 {
+        grid-template-columns: repeat(4, minmax(9rem, 1fr));
       }
 
       .table-row.table-header,
-      .table-row-3.table-header {
+      .table-row-4.table-header {
         border: none;
       }
 
@@ -707,16 +707,18 @@
           <div class="change-stream row-column col bg-block">
             <h2 class="table-title">progress</h2>
             <div class="per-namespace-progress" role="table">
-              <div class="table-row-3 table-header" role="row">
+              <div class="table-row-4 table-header" role="row">
                 <div class="table-cell" role="columnheader">Change Stream Events</div>
                 <div class="table-cell" role="columnheader">Deletes Caught</div>
                 <div class="table-cell" role="columnheader">Events To Catch Up</div>
+                <div class="table-cell" role="columnheader" id="last-read-time-header">Last Read Event Time</div>
               </div>
 
-              <div class="table-row-3" role="row">
+              <div class="table-row-4" role="row">
                 <div class="table-cell" role="cell" id="change-stream-events"></div>
                 <div class="table-cell" role="cell" id="deletes-caught"></div>
                 <div class="table-cell" role="cell" id="events-to-catch-up"></div>
+                <div class="table-cell" role="cell" id="last-read-time"></div>
               </div>
             </div>
           </div>
@@ -1044,6 +1046,11 @@
             document.getElementById("change-stream-events").textContent = data.RunnerSyncProgress.ChangeStreamEvents;
             document.getElementById("deletes-caught").textContent = data.RunnerSyncProgress.DeletesCaught;
             document.getElementById("events-to-catch-up").textContent = data.RunnerSyncProgress.Lag;
+            if (Date.parse(data.RunnerSyncProgress.ChangeStreamLastTime).valueOf() > 0) {
+              document.getElementById("last-read-time").textContent = data.RunnerSyncProgress.ChangeStreamLastTime;
+            } else {
+              document.getElementById("last-read-time").textContent = "Unavailable";
+            }
           }
 
           // Render verification result


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Last Read Event Time” to the Change Stream progress view, showing the timestamp of the latest processed event.
  * Streamed update responses now include time markers so clients receive the cluster time associated with emitted updates.
  * Status reports and local runner views now surface the last change-stream read time, improving visibility into synchronization progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->