### PR TITLE
Add ability to do --mode=InitialSync

### DIFF
--- a/internal/app/options/flags.go
+++ b/internal/app/options/flags.go
@@ -33,7 +33,7 @@ const (
 	cosmosDefaultMaxNumNamespaces = 8
 )
 
-var validModes = []string{iface.SyncModeFull, iface.SyncModeCDC}
+var validModes = []string{iface.SyncModeFull, iface.SyncModeCDC, iface.SyncModeInitialSync}
 
 const defaultMode = iface.SyncModeFull
 

--- a/protocol/iface/connector.go
+++ b/protocol/iface/connector.go
@@ -76,8 +76,9 @@ const (
 )
 
 const (
-	SyncModeFull = "Full"
-	SyncModeCDC  = "CDC"
+	SyncModeFull        = "Full"
+	SyncModeCDC         = "CDC"
+	SyncModeInitialSync = "InitialSync"
 )
 
 type ProgressMetrics struct {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Initial Sync mode selectable via the mode flag, separating one-time loads from continuous updates.

* **Bug Fixes**
  * Initial Sync now skips change-stream/LSN tracking and update planning, preventing premature updates and ensuring safer resume handling.

* **Refactor**
  * Consolidated progress update logic for more reliable streaming.
  * Ensures a final progress update on cancellation and maintains update cadence.
  * Emits elapsed time and overall progress/throughput in progress events.
  * Improves error handling during progress serialization without interrupting streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->