### PR TITLE
Add app name to mongo

### DIFF
--- a/connectors/mongo/conn.go
+++ b/connectors/mongo/conn.go
@@ -893,7 +893,7 @@ func MongoClient(ctx context.Context, settings ConnectorSettings) (*mongo.Client
 	// Connect to the MongoDB instance
 	ctxConnect, cancelConnect := context.WithTimeout(ctx, settings.ServerConnectTimeout)
 	defer cancelConnect()
-	clientOptions := moptions.Client().ApplyURI(settings.ConnectionString).SetConnectTimeout(settings.ServerConnectTimeout)
+	clientOptions := moptions.Client().SetAppName("dsync").ApplyURI(settings.ConnectionString).SetConnectTimeout(settings.ServerConnectTimeout)
 	client, err := mongo.Connect(ctxConnect, clientOptions)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * MongoDB connections now include the application name "dsync" for improved identification in monitoring and logs.
  * Makes it easier for operations to attribute and filter database connections by this application.
  * No changes to connection behavior or timeouts; no user action required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->