### PR TITLE
Support better batching on writer

### DIFF
--- a/connectors/common/base.go
+++ b/connectors/common/base.go
@@ -43,6 +43,7 @@ type ConnectorSettings struct {
 	NumParallelCopiers        int
 	NumParallelWriters        int
 	MaxWriterBatchSize        int
+	MultinamespaceBatcher     bool
 	ResumeTokenUpdateInterval time.Duration
 	TransformClient           adiomv1connect.TransformServiceClient
 	SourceDataType            adiomv1.DataType
@@ -784,7 +785,7 @@ func (c *connector) StartWriteFromChannel(flowId iface.FlowID, dataChannelID ifa
 	writerProgress.dataMessages.Store(0)
 
 	// create a batch assembly
-	flowParallelWriter := NewParallelWriter(c.flowCtx, c, c.settings.NumParallelWriters, c.settings.MaxWriterBatchSize)
+	flowParallelWriter := NewParallelWriter(c.flowCtx, c, c.settings.NumParallelWriters, c.settings.MaxWriterBatchSize, c.settings.MultinamespaceBatcher)
 	flowParallelWriter.Start()
 
 	// start printing progress

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -241,6 +241,7 @@ func runDsync(c *cli.Context) error {
 		NumParallelIntegrityCheckTasks: o.NumParallelIntegrityCheckTasks,
 		CdcResumeTokenUpdateInterval:   o.CdcResumeTokenUpdateInterval,
 		WriterMaxBatchSize:             o.WriterMaxBatchSize,
+		MultinamespaceBatcher:          o.MultinamespaceBatcher,
 		SyncMode:                       o.Mode,
 		ReverseRequestedFlag:           o.Reverse,
 	})

--- a/internal/app/options/flags.go
+++ b/internal/app/options/flags.go
@@ -144,6 +144,11 @@ func GetFlagsAndBeforeFunc() ([]cli.Flag, cli.BeforeFunc) {
 			Required: false,
 			Hidden:   true,
 		}),
+		altsrc.NewBoolFlag(&cli.BoolFlag{
+			Name:     "namespace-batcher",
+			Required: false,
+			Hidden:   true,
+		}),
 		altsrc.NewIntFlag(&cli.IntFlag{
 			Name:     "parallel-copiers",
 			Required: false,

--- a/internal/app/options/options.go
+++ b/internal/app/options/options.go
@@ -37,6 +37,7 @@ type Options struct {
 	NumParallelIntegrityCheckTasks int
 	CdcResumeTokenUpdateInterval   time.Duration
 	WriterMaxBatchSize             int
+	MultinamespaceBatcher          bool
 	Mode                           string
 }
 
@@ -67,6 +68,7 @@ func NewFromCLIContext(c *cli.Context) (Options, error) {
 	o.NumParallelIntegrityCheckTasks = c.Int("parallel-integrity-check-workers")
 	o.CdcResumeTokenUpdateInterval = time.Duration(c.Int("cdc-resume-token-interval")) * time.Second
 	o.WriterMaxBatchSize = c.Int("writer-batch-size")
+	o.MultinamespaceBatcher = c.Bool("namespace-batcher")
 	o.Mode = c.String("mode")
 	o.Reverse = c.Bool("reverse")
 

--- a/protocol/iface/transport.go
+++ b/protocol/iface/transport.go
@@ -39,6 +39,7 @@ const (
 	MutationType_InsertBatch
 	MutationType_Update
 	MutationType_Delete
+	MutationType_Ignore
 
 	MutationType_Barrier
 )

--- a/runners/local/runner.go
+++ b/runners/local/runner.go
@@ -76,6 +76,7 @@ type RunnerLocalSettings struct {
 	CdcResumeTokenUpdateInterval   time.Duration
 	WriterMaxBatchSize             int
 	SyncMode                       string
+	MultinamespaceBatcher          bool
 }
 
 const (
@@ -101,6 +102,7 @@ func NewRunnerLocal(settings RunnerLocalSettings) *RunnerLocal {
 		NumParallelCopiers:        settings.InitialSyncNumParallelCopiers,
 		NumParallelWriters:        settings.NumParallelWriters,
 		MaxWriterBatchSize:        settings.WriterMaxBatchSize,
+		MultinamespaceBatcher:     settings.MultinamespaceBatcher,
 		ResumeTokenUpdateInterval: settings.CdcResumeTokenUpdateInterval,
 		TransformClient:           settings.TransformClient,
 		SourceDataType:            settings.SrcDataType,


### PR DESCRIPTION
* Adjust queue size based on the max batch size
  * Hack to clog up the queue with dummy values for initial sync
* Add flag to batch by namespace

(these are currently hidden params)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Optional multi-namespace batching mode to group and process writes per namespace; hidden CLI flag --namespace-batcher to enable it.
- Performance
  - Better throughput and fairness under concurrent namespaces with per-namespace parallel batching and improved flushing behavior.
- Reliability
  - Throttling for large insert bursts to prevent writer clogging and maintain stability.
- Observability
  - Warning logs when throttling is applied during heavy insert workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->