### PR TITLE
Add /dev/null id option and surface resume token update interval.

### DIFF
--- a/cmd/grpcexample/main.go
+++ b/cmd/grpcexample/main.go
@@ -32,7 +32,7 @@ func main() {
 		_ = s.Serve(l)
 	}()
 
-	nullConn := null.NewConn(false, 0, 0)
+	nullConn := null.NewConn("", false, 0, 0)
 	mux := http.NewServeMux()
 	path, handler := adiomv1connect.NewConnectorServiceHandler(nullConn)
 	tpath, thandler := adiomv1connect.NewTransformServiceHandler(transform.NewIdentityTransform())

--- a/connectors/mongo/conn.go
+++ b/connectors/mongo/conn.go
@@ -561,7 +561,7 @@ func createChangeStreamNamespaceFilterFromNamespaces(namespaces []iface.Namespac
 }
 
 func convertChangeStreamEventToUpdate(change bson.M) (*adiomv1.Update, error) {
-	slog.Debug(fmt.Sprintf("Converting change stream event %v", change))
+	// slog.Debug(fmt.Sprintf("Converting change stream event %v", change))
 
 	optype := change["operationType"].(string)
 	var update *adiomv1.Update

--- a/connectors/null/connector.go
+++ b/connectors/null/connector.go
@@ -21,6 +21,7 @@ import (
 )
 
 type conn struct {
+	id          string
 	logJson     bool
 	sleep       time.Duration
 	sleepJitter time.Duration
@@ -38,6 +39,7 @@ func (c *conn) GetInfo(context.Context, *connect.Request[adiomv1.GetInfoRequest]
 		all = append(all, adiomv1.DataType(d))
 	}
 	return connect.NewResponse(&adiomv1.GetInfoResponse{
+		Id:     c.id,
 		DbType: "/dev/null",
 		Capabilities: &adiomv1.Capabilities{
 			Sink: &adiomv1.Capabilities_Sink{SupportedDataTypes: all},
@@ -143,6 +145,6 @@ func (c *conn) WriteUpdates(ctx context.Context, r *connect.Request[adiomv1.Writ
 	return connect.NewResponse(&adiomv1.WriteUpdatesResponse{}), nil
 }
 
-func NewConn(logJson bool, sleep time.Duration, sleepJitter time.Duration) adiomv1connect.ConnectorServiceHandler {
-	return &conn{logJson, sleep, sleepJitter}
+func NewConn(id string, logJson bool, sleep time.Duration, sleepJitter time.Duration) adiomv1connect.ConnectorServiceHandler {
+	return &conn{id, logJson, sleep, sleepJitter}
 }

--- a/connectors/null/connector_test.go
+++ b/connectors/null/connector_test.go
@@ -19,14 +19,14 @@ import (
 // Standard test suite for the connector interface
 func TestNullConnectorSuite(t *testing.T) {
 	tSuite := test.NewConnectorTestSuite(func() iface.Connector {
-		return common.NewLocalConnector("test", NewConn(false, 0, 0), common.ConnectorSettings{})
+		return common.NewLocalConnector("test", NewConn("", false, 0, 0), common.ConnectorSettings{})
 	}, nil)
 	suite.Run(t, tSuite)
 }
 
 func TestNullConnectorSuite2(t *testing.T) {
 	tSuite := test2.NewConnectorTestSuite("test", func() adiomv1connect.ConnectorServiceClient {
-		return test2.ClientFromHandler(NewConn(false, 0, 0))
+		return test2.ClientFromHandler(NewConn("", false, 0, 0))
 	}, nil, nil, 0, 0)
 	suite.Run(t, tSuite)
 }

--- a/internal/app/options/connectorflags.go
+++ b/internal/app/options/connectorflags.go
@@ -288,8 +288,12 @@ func GetRegisteredConnectors() []RegisteredConnector {
 					Name:  "log-json",
 					Usage: "Convert data to json and log INFO",
 				},
+				&cli.StringFlag{
+					Name:  "id",
+					Usage: "A fixed id for the connector",
+				},
 			}, func(c *cli.Context, args []string, as AdditionalSettings) (adiomv1connect.ConnectorServiceHandler, error) {
-				return null.NewConn(c.Bool("log-json"), c.Duration("sleep"), c.Duration("sleep-jitter")), nil
+				return null.NewConn(c.String("id"), c.Bool("log-json"), c.Duration("sleep"), c.Duration("sleep-jitter")), nil
 			}),
 		},
 		{

--- a/internal/app/options/flags.go
+++ b/internal/app/options/flags.go
@@ -144,6 +144,11 @@ func GetFlagsAndBeforeFunc() ([]cli.Flag, cli.BeforeFunc) {
 			Required: false,
 			Hidden:   true,
 		}),
+		altsrc.NewDurationFlag(&cli.DurationFlag{
+			Name:     "cdc-resume-token-interval",
+			Required: false,
+			Hidden:   true,
+		}),
 		altsrc.NewBoolFlag(&cli.BoolFlag{
 			Name:     "namespace-batcher",
 			Required: false,

--- a/internal/app/options/options.go
+++ b/internal/app/options/options.go
@@ -66,7 +66,7 @@ func NewFromCLIContext(c *cli.Context) (Options, error) {
 	o.InitialSyncNumParallelCopiers = c.Int("parallel-copiers")
 	o.NumParallelWriters = c.Int("parallel-writers")
 	o.NumParallelIntegrityCheckTasks = c.Int("parallel-integrity-check-workers")
-	o.CdcResumeTokenUpdateInterval = time.Duration(c.Int("cdc-resume-token-interval")) * time.Second
+	o.CdcResumeTokenUpdateInterval = c.Duration("cdc-resume-token-interval")
 	o.WriterMaxBatchSize = c.Int("writer-batch-size")
 	o.MultinamespaceBatcher = c.Bool("namespace-batcher")
 	o.Mode = c.String("mode")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Null connector now supports a user-defined ID; the ID is returned in connector info.
  - Added CLI flag --id for the null connector to set its ID.
  - Added a hidden CLI flag cdc-resume-token-interval to control resume token update frequency using duration values (e.g., “30s”, “5m”).

- Chores
  - Updated example app and tests to use the new null connector initialization.
  - Reduced noisy debug logging in the Mongo connector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->