### PR TITLE
Add web host param

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -103,7 +103,7 @@ func runDsync(c *cli.Context) error {
 	if needWebServer {
 		wsErrorLog = new(logger.ReverseBuffer)
 		lo.ErrorView = wsErrorLog
-		host := fmt.Sprintf("localhost:%d", o.WebPort)
+		host := fmt.Sprintf("%v:%d", o.WebHost, o.WebPort)
 		slog.Info("Starting web server to serve progress report on " + host)
 		server = &http.Server{
 			Addr:              host,

--- a/internal/app/options/flags.go
+++ b/internal/app/options/flags.go
@@ -133,6 +133,11 @@ func GetFlagsAndBeforeFunc() ([]cli.Flag, cli.BeforeFunc) {
 			Usage: "specify the port for web server",
 			Value: DefaultWebPort,
 		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:  "web-host",
+			Usage: "specify the host for web server",
+			Value: "localhost",
+		}),
 		&cli.StringFlag{
 			Name:    "config",
 			Aliases: []string{"c"},

--- a/internal/app/options/options.go
+++ b/internal/app/options/options.go
@@ -30,6 +30,7 @@ type Options struct {
 
 	PprofPort uint
 	WebPort   uint
+	WebHost   string
 
 	LoadLevel                      string
 	InitialSyncNumParallelCopiers  int
@@ -62,6 +63,7 @@ func NewFromCLIContext(c *cli.Context) (Options, error) {
 	o.LoadLevel = c.String("load-level")
 	o.PprofPort = c.Uint("pprof-port")
 	o.WebPort = c.Uint("web-port")
+	o.WebHost = c.String("web-host")
 
 	o.InitialSyncNumParallelCopiers = c.Int("parallel-copiers")
 	o.NumParallelWriters = c.Int("parallel-writers")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a CLI flag to set the web server host (e.g., --web-host), enabling binding to a specific interface instead of always using localhost.
  - Server now starts on the configured host and port, and logs reflect the full host:port address.
  - Improves flexibility for deployments in containers, remote machines, or custom network setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->