### PR TITLE
Add verify max tasks.

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -229,6 +229,7 @@ func runDsync(c *cli.Context) error {
 		NsFromString:                   namespaces,
 		VerifyRequestedFlag:            o.Verify || o.VerifyQuickCount,
 		VerifyQuickCountFlag:           o.VerifyQuickCount,
+		VerifyMaxTasks:                 o.VerifyMaxTasks,
 		CleanupRequestedFlag:           o.Cleanup,
 		FlowStatusReportingInterval:    10,
 		AdvancedProgressRecalcInterval: throughputUpdateInterval,

--- a/internal/app/options/flags.go
+++ b/internal/app/options/flags.go
@@ -76,6 +76,11 @@ func GetFlagsAndBeforeFunc() ([]cli.Flag, cli.BeforeFunc) {
 			Usage:    "perform a data integrity check for an existing flow by doing a quick count by namespace",
 			Category: "Special Commands",
 		}),
+		altsrc.NewIntFlag(&cli.IntFlag{
+			Name:     "verify-max-tasks",
+			Usage:    "Specify max number of tasks to run verification on. Will randomly select which tasks are included.",
+			Category: "Special Commands",
+		}),
 		altsrc.NewBoolFlag(&cli.BoolFlag{
 			Name:     "cleanup",
 			Usage:    "cleanup metadata for an existing flow",

--- a/internal/app/options/options.go
+++ b/internal/app/options/options.go
@@ -22,6 +22,7 @@ type Options struct {
 
 	Verify           bool
 	VerifyQuickCount bool
+	VerifyMaxTasks   int
 	Cleanup          bool
 	Progress         bool
 	Reverse          bool
@@ -57,6 +58,7 @@ func NewFromCLIContext(c *cli.Context) (Options, error) {
 	o.NamespaceFrom = c.StringSlice("namespace")
 	o.Verify = c.Bool("verify")
 	o.VerifyQuickCount = c.Bool("verify-quick-count")
+	o.VerifyMaxTasks = c.Int("verify-max-tasks")
 	o.Cleanup = c.Bool("cleanup")
 	o.Progress = c.Bool("progress")
 	o.Pprof = c.Bool("pprof")

--- a/internal/build/vars.go
+++ b/internal/build/vars.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	VersionStr   = "0.19.0"
+	VersionStr   = "0.20.0"
 	CopyrightStr = "Adiom Inc., 2025"
 )
 

--- a/protocol/iface/coordinator.go
+++ b/protocol/iface/coordinator.go
@@ -40,6 +40,7 @@ type FlowIntegrityStatus struct {
 
 type IntegrityCheckOptions struct {
 	QuickCount bool
+	MaxTasks   int
 }
 
 type ConnectorDetails struct {

--- a/runners/local/runner.go
+++ b/runners/local/runner.go
@@ -62,6 +62,7 @@ type RunnerLocalSettings struct {
 
 	VerifyRequestedFlag  bool
 	VerifyQuickCountFlag bool
+	VerifyMaxTasks       int
 	CleanupRequestedFlag bool
 	ReverseRequestedFlag bool
 
@@ -225,7 +226,7 @@ func (r *RunnerLocal) Run() error {
 	//don't start the flow if the verify flag is set
 	if r.settings.VerifyRequestedFlag {
 		r.runnerProgress.SyncState = "Verify"
-		integrityCheckRes, err := r.coord.PerformFlowIntegrityCheck(r.integrityCtx, flowID, iface.IntegrityCheckOptions{QuickCount: r.settings.VerifyQuickCountFlag})
+		integrityCheckRes, err := r.coord.PerformFlowIntegrityCheck(r.integrityCtx, flowID, iface.IntegrityCheckOptions{QuickCount: r.settings.VerifyQuickCountFlag, MaxTasks: r.settings.VerifyMaxTasks})
 		if err != nil {
 			r.runnerProgress.VerificationResult = "ERROR"
 			slog.Error("Data integrity check: ERROR")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added --verify-max-tasks CLI flag to cap the number of tasks verified.
  - Integrity checks now sample a random subset of tasks when a cap is set, applied to both quick and full verification modes, with subset selection logged.

- Chores
  - Version updated to 0.20.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->