### PR TITLE
Use custom in memory verifier.

### DIFF
--- a/connectors/common/base.go
+++ b/connectors/common/base.go
@@ -9,6 +9,7 @@ package common
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"hash"
@@ -20,6 +21,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	"connectrpc.com/connect"
 	adiomv1 "github.com/adiom-data/dsync/gen/adiom/v1"
@@ -28,6 +30,7 @@ import (
 	"github.com/adiom-data/dsync/protocol/iface"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/cespare/xxhash"
+	"github.com/google/uuid"
 	"go.akshayshah.org/memhttp"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -91,6 +94,43 @@ func isRetryable(err error) bool {
 // GetConnectorStatus implements iface.Connector.
 func (c *connector) GetConnectorStatus(flowId iface.FlowID) iface.ConnectorStatus {
 	return c.progressTracker.CopyStatus()
+}
+
+func IDPartToString(a any) string {
+	switch t := a.(type) {
+	case primitive.ObjectID:
+		return t.Hex()
+	case string:
+		return t
+	case primitive.Binary:
+		if t.Subtype == bson.TypeBinaryUUID {
+			id, err := uuid.FromBytes(t.Data)
+			if err == nil {
+				return id.String()
+			}
+		}
+		if utf8.Valid(t.Data) {
+			return string(t.Data)
+		}
+		return base64.StdEncoding.EncodeToString(t.Data)
+	default:
+		return fmt.Sprintf("%v", a)
+	}
+}
+
+func IDToString(id []bson.RawValue) (string, error) {
+	var sb strings.Builder
+	for i, part := range id {
+		var a any
+		if err := bson.UnmarshalValue(part.Type, part.Value, &a); err != nil {
+			return "", fmt.Errorf("err in unmarshal value %w", err)
+		}
+		if i != 0 {
+			sb.WriteByte('|')
+		}
+		sb.WriteString(IDPartToString(a))
+	}
+	return sb.String(), nil
 }
 
 func HashBson(hasher hash.Hash64, b bson.Raw, arr bool, projection map[string]interface{}) error {
@@ -189,12 +229,22 @@ func (c *connector) IntegrityCheck(ctx context.Context, task iface.IntegrityChec
 
 		for _, data := range res.Msg.Data {
 			hasher.Reset()
-			err = HashBson(hasher, bson.Raw(data), false, nil)
-			if err != nil {
+			d := bson.Raw(data)
+			if err := HashBson(hasher, d, false, nil); err != nil {
 				slog.Error(fmt.Sprintf("Error hashing during integrity check: %v", err))
 				return iface.ConnectorDataIntegrityCheckResult{}, err
 			}
-			hash ^= hasher.Sum64()
+			h := hasher.Sum64()
+			if task.MemFn != nil {
+				id := d.Lookup("_id")
+				var a any
+				if err := bson.UnmarshalValue(id.Type, id.Value, &a); err != nil {
+					slog.Error("Error getting id during integrity check", "err", err)
+					return iface.ConnectorDataIntegrityCheckResult{}, err
+				}
+				task.MemFn(IDPartToString(a), h)
+			}
+			hash ^= h
 			count += 1
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -12,12 +12,12 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.19.3
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.43.4
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.25.6
+	github.com/benbjohnson/clock v1.3.5
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cespare/xxhash v1.1.0
 	github.com/gdamore/tcell/v2 v2.8.1
 	github.com/jackc/pglogrepl v0.0.0-20250509230407-a9884f6bd75a
 	github.com/jackc/pgx/v5 v5.7.5
-	github.com/jrhy/mast v1.2.33
 	github.com/lmittmann/tint v1.1.2
 	github.com/mitchellh/hashstructure v1.1.0
 	github.com/rivo/tview v0.0.0-20250625164341-a4a78f1e05cb
@@ -63,7 +63,6 @@ require (
 	github.com/go-openapi/strfmt v0.23.0 // indirect
 	github.com/go-openapi/swag v0.23.1 // indirect
 	github.com/go-openapi/validate v0.24.0 // indirect
-	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
@@ -72,7 +71,6 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
-	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.34.0 h1:NFOJ/NXEGV4Rq//71Hs1jC/NvPs1
 github.com/aws/aws-sdk-go-v2/service/sts v1.34.0/go.mod h1:7ph2tGpfQvwzgistp2+zga9f+bCjlQJPkPUmMgDSD7w=
 github.com/aws/smithy-go v1.22.4 h1:uqXzVZNuNexwc/xrh6Tb56u89WDlJY6HS+KC0S4QSjw=
 github.com/aws/smithy-go v1.22.4/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
+github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
+github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/brianvoe/gofakeit/v7 v7.2.1 h1:AGojgaaCdgq4Adzrd2uWdbGNDyX6MWNhHdQBraNfOHI=
 github.com/brianvoe/gofakeit/v7 v7.2.1/go.mod h1:QXuPeBw164PJCzCUZVmgpgHJ3Llj49jSLVkKPMtxtxA=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
@@ -147,8 +149,6 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
-github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jackc/pgio v1.0.0 h1:g12B9UwVnzGhueNavwioyEEpAmqMe1E/BN9ES+8ovkE=
 github.com/jackc/pgio v1.0.0/go.mod h1:oP+2QK2wFfUWgr+gxjoBH9KGBb31Eio69xUb0w5bYf8=
@@ -165,8 +165,6 @@ github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFr
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-github.com/jrhy/mast v1.2.33 h1:jjEIvbIL3Ik/5XOi2Xjalt1WWF5hHZzKecbGQfYBd2c=
-github.com/jrhy/mast v1.2.33/go.mod h1:6v9QI2+vESNUjcsk4jLnl/cH13ktU7If0GwBF+IetVM=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
@@ -181,8 +179,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/leanovate/gopter v0.2.11 h1:vRjThO1EKPb/1NsDXuDrzldR28RLkBflWYcU9CvzWu4=
-github.com/leanovate/gopter v0.2.11/go.mod h1:aK3tzZP/C+p1m3SPRE4SYZFGP7jjkuSI4f7Xvpt0S9c=
 github.com/lmittmann/tint v1.1.2 h1:2CQzrL6rslrsyjqLDwD11bZ5OpLBPU+g3G/r5LSfS8w=
 github.com/lmittmann/tint v1.1.2/go.mod h1:HIS3gSy7qNwGCj+5oRjAutErFBl4BzdQP6cJZ0NfMwE=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
@@ -197,8 +193,6 @@ github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsI
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 h1:lYpkrQH5ajf0OXOcUbGjvZxxijuBwbbmlSxLiuofa+g=
-github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1/go.mod h1:pD8RvIylQ358TN4wwqatJ8rNavkEINozVn9DtGI3dfQ=
 github.com/mitchellh/hashstructure v1.1.0 h1:P6P1hdjqAAknpY/M1CGipelZgp+4y9ja9kmUZPXP+H0=
 github.com/mitchellh/hashstructure v1.1.0/go.mod h1:xUDAozZz0Wmdiufv0uyhnHkUTN6/6d8ulp4AwfLKrmA=
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -227,8 +227,9 @@ func runDsync(c *cli.Context) error {
 		Dst:                            dst,
 		StateStoreConnString:           o.StateStoreConnString,
 		NsFromString:                   namespaces,
-		VerifyRequestedFlag:            o.Verify || o.VerifyQuickCount,
+		VerifyRequestedFlag:            o.Verify || o.VerifyQuickCount || o.VerifyMem,
 		VerifyQuickCountFlag:           o.VerifyQuickCount,
+		VerifyMemFlag:                  o.VerifyMem,
 		VerifyMaxTasks:                 o.VerifyMaxTasks,
 		CleanupRequestedFlag:           o.Cleanup,
 		FlowStatusReportingInterval:    10,
@@ -372,7 +373,7 @@ func runDsync(c *cli.Context) error {
 		err := r.Setup(runnerCtx)
 		if err == nil {
 			err = r.Run()
-			if !o.Verify && !o.VerifyQuickCount { //if verification was requested, the user should be able to see the results
+			if !o.Verify && !o.VerifyQuickCount && !o.VerifyMem { //if verification was requested, the user should be able to see the results
 				runnerCancelFunc()
 			}
 		} else {

--- a/internal/app/options/flags.go
+++ b/internal/app/options/flags.go
@@ -76,6 +76,11 @@ func GetFlagsAndBeforeFunc() ([]cli.Flag, cli.BeforeFunc) {
 			Usage:    "perform a data integrity check for an existing flow by doing a quick count by namespace",
 			Category: "Special Commands",
 		}),
+		altsrc.NewBoolFlag(&cli.BoolFlag{
+			Name:     "verify-mem",
+			Usage:    "perform a more involved memory intensive integrity check for an existing flow",
+			Category: "Special Commands",
+		}),
 		altsrc.NewIntFlag(&cli.IntFlag{
 			Name:     "verify-max-tasks",
 			Usage:    "Specify max number of tasks to run verification on. Will randomly select which tasks are included.",

--- a/internal/app/options/options.go
+++ b/internal/app/options/options.go
@@ -22,6 +22,7 @@ type Options struct {
 
 	Verify           bool
 	VerifyQuickCount bool
+	VerifyMem        bool
 	VerifyMaxTasks   int
 	Cleanup          bool
 	Progress         bool
@@ -58,6 +59,7 @@ func NewFromCLIContext(c *cli.Context) (Options, error) {
 	o.NamespaceFrom = c.StringSlice("namespace")
 	o.Verify = c.Bool("verify")
 	o.VerifyQuickCount = c.Bool("verify-quick-count")
+	o.VerifyMem = c.Bool("verify-mem")
 	o.VerifyMaxTasks = c.Int("verify-max-tasks")
 	o.Cleanup = c.Bool("cleanup")
 	o.Progress = c.Bool("progress")

--- a/pkg/verify/ds/ds.go
+++ b/pkg/verify/ds/ds.go
@@ -1,0 +1,137 @@
+package ds
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/benbjohnson/clock"
+)
+
+func NewVerifier(ctx context.Context, clock clock.Clock, delay time.Duration, poll time.Duration, limit int) *verifier {
+	frontier := NewFrontier()
+	v := &verifier{
+		clock:    clock,
+		allNodes: map[string]*Node{},
+		mismatch: map[string]struct{}{},
+		frontier: frontier,
+	}
+
+	if delay > 0 && poll > 0 {
+		go func() {
+			ticker := clock.Ticker(poll)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ticker.C:
+					v.Update(delay, limit)
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	return v
+}
+
+type verifier struct {
+	clock    clock.Clock
+	allNodes map[string]*Node
+	mismatch map[string]struct{}
+	frontier *frontierImpl
+	mut      sync.Mutex
+}
+
+// MismatchCountAndTotal implements Verifier.
+func (v *verifier) MismatchCountAndTotal() (int64, int64) {
+	v.mut.Lock()
+	defer v.mut.Unlock()
+	return int64(len(v.mismatch)), int64(len(v.allNodes))
+}
+
+func (v *verifier) Update(delay time.Duration, limit int) {
+	v.mut.Lock()
+	defer v.mut.Unlock()
+	items := v.frontier.Delete(v.clock.Now().Add(-delay).UnixMilli(), limit)
+	for _, item := range items {
+		if item.Left != item.Right {
+			v.mismatch[item.ID] = struct{}{}
+		} else if item.Left == 0 && item.Right == 0 {
+			delete(v.allNodes, item.ID)
+		}
+	}
+}
+
+// Find implements Verifier.
+func (v *verifier) Find(limit int) []Result {
+	v.mut.Lock()
+	defer v.mut.Unlock()
+	var res []Result
+	for k := range v.mismatch {
+		n := v.allNodes[k]
+		res = append(res, Result{
+			ID:    n.ID,
+			Left:  n.Left,
+			Right: n.Right,
+		})
+		if limit != 0 && len(res) >= limit {
+			break
+		}
+	}
+	return res
+}
+
+// Put implements Verifier.
+func (v *verifier) Put(id string, left bool, h uint64, direct bool) {
+	v.mut.Lock()
+	defer v.mut.Unlock()
+	existing, ok := v.allNodes[id]
+	if !ok {
+		if h == 0 {
+			return
+		}
+		newNode := &Node{
+			ID: id,
+		}
+		if left {
+			newNode.Left = h
+		} else {
+			newNode.Right = h
+		}
+		v.allNodes[id] = newNode
+		if direct {
+			v.mismatch[id] = struct{}{}
+		} else {
+			v.frontier.Put(id, newNode, v.clock.Now().UnixMilli())
+		}
+		return
+	}
+	if left {
+		existing.Left = h
+	} else {
+		existing.Right = h
+	}
+	id = existing.ID
+	if direct {
+		if existing.Left != existing.Right {
+			v.mismatch[id] = struct{}{}
+		} else {
+			delete(v.mismatch, id)
+			if existing.Left == 0 && existing.Right == 0 {
+				delete(v.allNodes, id)
+			}
+		}
+	} else {
+		v.frontier.Put(id, existing, v.clock.Now().UnixMilli())
+		delete(v.mismatch, id)
+	}
+}
+
+type Node struct {
+	ID    string
+	Left  uint64
+	Right uint64
+}
+
+var _ Verifier = &verifier{}

--- a/pkg/verify/ds/frontier.go
+++ b/pkg/verify/ds/frontier.go
@@ -1,0 +1,87 @@
+package ds
+
+func NewFrontier() *frontierImpl {
+	return &frontierImpl{
+		Items: map[string]*ListNode{},
+	}
+}
+
+type frontierImpl struct {
+	Newest *ListNode
+	Oldest *ListNode
+	Items  map[string]*ListNode
+}
+
+func (f *frontierImpl) Put(k string, v *Node, t int64) {
+	if f.Newest == nil {
+		newNode := &ListNode{
+			Node:      v,
+			Timestamp: t,
+		}
+		f.Newest = newNode
+		f.Oldest = newNode
+		f.Items[k] = newNode
+	} else {
+		cur, ok := f.Items[k]
+		if !ok {
+			newNode := &ListNode{
+				Node:      v,
+				Timestamp: t,
+				Older:     f.Newest,
+			}
+			f.Newest.Newer = newNode
+			f.Newest = newNode
+			f.Items[k] = newNode
+		} else if f.Newest == cur {
+			cur.Timestamp = t
+		} else if f.Oldest == cur {
+			cur.Timestamp = t
+			f.Oldest = cur.Newer
+			cur.Newer.Older = nil
+			cur.Newer = nil
+			cur.Older = f.Newest
+			f.Newest.Newer = cur
+			f.Newest = cur
+		} else {
+			cur.Timestamp = t
+			cur.Newer.Older = cur.Older
+			cur.Older.Newer = cur.Newer
+			cur.Newer = nil
+			cur.Older = f.Newest
+			f.Newest.Newer = cur
+			f.Newest = cur
+		}
+	}
+}
+
+func (f *frontierImpl) Check(k string) bool {
+	_, ok := f.Items[k]
+	return ok
+}
+
+func (f *frontierImpl) Delete(t int64, limit int) []*Node {
+	if f.Oldest != nil {
+		var res []*Node
+		cur := f.Oldest
+		for cur != nil && cur.Timestamp <= t && (limit == 0 || len(res) < limit) {
+			res = append(res, cur.Node)
+			delete(f.Items, cur.Node.ID)
+			cur = cur.Newer
+		}
+		if cur == nil {
+			f.Newest = nil
+		} else {
+			cur.Older = nil
+		}
+		f.Oldest = cur
+		return res
+	}
+	return nil
+}
+
+type ListNode struct {
+	*Node
+	Timestamp int64
+	Newer     *ListNode
+	Older     *ListNode
+}

--- a/pkg/verify/ds/iface.go
+++ b/pkg/verify/ds/iface.go
@@ -1,0 +1,13 @@
+package ds
+
+type Result struct {
+	ID    string
+	Left  uint64
+	Right uint64
+}
+
+type Verifier interface {
+	Put(id string, left bool, v uint64, direct bool)
+	Find(int) []Result
+	MismatchCountAndTotal() (int64, int64)
+}

--- a/pkg/verify/ds/verifier_test.go
+++ b/pkg/verify/ds/verifier_test.go
@@ -1,0 +1,72 @@
+package ds_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/adiom-data/dsync/pkg/verify/ds"
+	"github.com/benbjohnson/clock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFrontier(t *testing.T) {
+	frontier := ds.NewFrontier()
+
+	nodeA := &ds.Node{ID: "a"}
+	nodeB := &ds.Node{ID: "b"}
+	nodeC := &ds.Node{ID: "c"}
+	frontier.Put("a", nodeA, 100)
+	frontier.Put("b", nodeB, 101)
+	frontier.Put("c", nodeC, 102)
+	frontier.Put("c", nodeC, 103)
+	frontier.Put("b", nodeB, 104)
+	frontier.Put("a", nodeA, 105)
+
+	assert.True(t, frontier.Check("c"))
+	assert.True(t, frontier.Check("b"))
+	assert.True(t, frontier.Check("a"))
+
+	assert.Empty(t, frontier.Delete(100, 0))
+	assert.Equal(t, []*ds.Node{nodeC}, frontier.Delete(103, 0))
+	assert.Equal(t, []*ds.Node{nodeB, nodeA}, frontier.Delete(110, 0))
+	assert.Empty(t, frontier.Delete(110, 0))
+}
+
+func TestVerifier(t *testing.T) {
+	ctx := context.Background()
+	clock := clock.NewMock()
+	clock.Set(time.Now())
+	verifier := ds.NewVerifier(ctx, clock, 0, 0, 0)
+	assert.Empty(t, verifier.Find(0))
+
+	verifier.Put("a", true, 1, true)
+	verifier.Put("b", true, 1, true)
+	assert.ElementsMatch(t, []ds.Result{{"a", 1, 0}, {"b", 1, 0}}, verifier.Find(0))
+
+	verifier.Put("a", false, 2, true)
+	verifier.Put("b", false, 1, true)
+	assert.Equal(t, []ds.Result{{"a", 1, 2}}, verifier.Find(0))
+
+	verifier.Put("a", false, 3, false)
+	assert.Empty(t, verifier.Find(0))
+
+	clock.Add(time.Minute)
+	verifier.Update(time.Minute, 0)
+	assert.Equal(t, []ds.Result{{"a", 1, 3}}, verifier.Find(0))
+
+	verifier.Put("a", false, 0, false)
+	assert.Empty(t, verifier.Find(0))
+
+	clock.Add(time.Minute)
+	verifier.Update(time.Minute, 0)
+	assert.Equal(t, []ds.Result{{"a", 1, 0}}, verifier.Find(0))
+
+	verifier.Put("a", true, 0, false)
+	verifier.Put("b", true, 0, false)
+	assert.Empty(t, verifier.Find(0))
+
+	clock.Add(time.Minute)
+	verifier.Update(time.Minute, 0)
+	assert.Equal(t, []ds.Result{{"b", 0, 1}}, verifier.Find(0))
+}

--- a/protocol/iface/connector.go
+++ b/protocol/iface/connector.go
@@ -29,6 +29,7 @@ type ConnectorCapabilities struct {
 type IntegrityCheckQuery struct {
 	Namespace string
 	CountOnly bool
+	MemFn     func(string, uint64)
 
 	PartitionKey string
 	Low          interface{}

--- a/protocol/iface/coordinator.go
+++ b/protocol/iface/coordinator.go
@@ -41,6 +41,7 @@ type FlowIntegrityStatus struct {
 type IntegrityCheckOptions struct {
 	QuickCount bool
 	MaxTasks   int
+	MemVerify  bool
 }
 
 type ConnectorDetails struct {

--- a/runners/local/runner.go
+++ b/runners/local/runner.go
@@ -62,6 +62,7 @@ type RunnerLocalSettings struct {
 
 	VerifyRequestedFlag  bool
 	VerifyQuickCountFlag bool
+	VerifyMemFlag        bool
 	VerifyMaxTasks       int
 	CleanupRequestedFlag bool
 	ReverseRequestedFlag bool
@@ -226,7 +227,7 @@ func (r *RunnerLocal) Run() error {
 	//don't start the flow if the verify flag is set
 	if r.settings.VerifyRequestedFlag {
 		r.runnerProgress.SyncState = "Verify"
-		integrityCheckRes, err := r.coord.PerformFlowIntegrityCheck(r.integrityCtx, flowID, iface.IntegrityCheckOptions{QuickCount: r.settings.VerifyQuickCountFlag, MaxTasks: r.settings.VerifyMaxTasks})
+		integrityCheckRes, err := r.coord.PerformFlowIntegrityCheck(r.integrityCtx, flowID, iface.IntegrityCheckOptions{QuickCount: r.settings.VerifyQuickCountFlag, MaxTasks: r.settings.VerifyMaxTasks, MemVerify: r.settings.VerifyMemFlag})
 		if err != nil {
 			r.runnerProgress.VerificationResult = "ERROR"
 			slog.Error("Data integrity check: ERROR")


### PR DESCRIPTION
Add use of custom verifier
* replace mast verifier
* a bit of a hack for --verify to avoid overcomplicating


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional memory-intensive integrity verification via new CLI flag --verify-mem and runner option; per-run verifier summaries and improved mismatch metrics.
  * Improved ID handling during integrity checks to support more ID formats.
* **Refactor**
  * Reworked in-memory verification pipeline for concurrent, namespaced verification with latency controls.
* **Tests**
  * Added tests covering verifier and frontier behavior.
* **Chores**
  * Updated dependencies (added clock; removed unused libraries).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->