### PR TITLE
Add a sample factor to mongodb planning

### DIFF
--- a/internal/app/options/connectorflags.go
+++ b/internal/app/options/connectorflags.go
@@ -356,6 +356,12 @@ func GetRegisteredConnectors() []RegisteredConnector {
 			Create: func(args []string, as AdditionalSettings) (adiomv1connect.ConnectorServiceHandler, []string, error) {
 				settings := mongo.ConnectorSettings{ConnectionString: args[0]}
 				return CreateHelper("MongoDB", "mongodb://connection-string [options]", append(MongoFlags(&settings), []cli.Flag{
+					altsrc.NewIntFlag(&cli.IntFlag{
+						Name:        "sample-factor",
+						Destination: &settings.SampleFactor,
+						Usage:       "Number of extra samples per partition",
+						Value:       10,
+					}),
 					altsrc.NewBoolFlag(&cli.BoolFlag{
 						Name:        "per-namespace-streams",
 						Usage:       "Each namespace has a separate stream",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a CLI flag “sample-factor” for the MongoDB connector to control sampling per partition; default is 1.
  - Sampling volume scales with the factor and target documents per partition, with an automatic cap at 5% of the collection size (warning logged when applied).
  - Sampling now includes alternating skip cycles driven by the factor.
  - Defaults remain unchanged for existing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->