### PR TITLE
add estimated partition count to Postgres reader

### DIFF
--- a/connectors/postgres/conn.go
+++ b/connectors/postgres/conn.go
@@ -262,8 +262,9 @@ func (c *conn) GeneratePlan(ctx context.Context, r *connect.Request[adiomv1.Gene
 					return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("unable to set initial cursor"))
 				}
 				partitions = append(partitions, &adiomv1.Partition{
-					Namespace: namespace,
-					Cursor:    encodedCursor,
+					Namespace:      namespace,
+					Cursor:         encodedCursor,
+					EstimatedCount: uint64(c.settings.TargetDocCountPerPartition),
 				})
 				last = k
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Initial data synchronization now utilizes improved capacity estimation for optimized partition distribution during database connections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->