### PR TITLE
Add way to configure cosmos internal keys

### DIFF
--- a/java/src/main/java/adiom/Config.java
+++ b/java/src/main/java/adiom/Config.java
@@ -1,9 +1,11 @@
 package adiom;
 
+import java.util.List;
 import java.util.Map;
 
 public class Config {
     public Map<String, NamespaceConfig> namespaces;
+    public List<String> cosmosInternalKeys;
 }
 
 class NamespaceConfig {

--- a/java/src/main/java/adiom/Main.java
+++ b/java/src/main/java/adiom/Main.java
@@ -88,7 +88,8 @@ public class Main {
 
     private static final Logger logger = LoggerFactory.getLogger(Main.class);
 
-    private static List<String> CosmosInternalKeys = Arrays.asList("_rid", "_self", "_etag", "_attachments", "_ts");
+    private static final List<String> DEFAULT_COSMOS_INTERNAL_KEYS = Arrays.asList("_rid", "_self", "_etag", "_attachments", "_ts");
+    private static List<String> CosmosInternalKeys;
     private static Config CONFIG;
     private static Cache<Long, CacheItem> CACHE = Caffeine.newBuilder().expireAfterAccess(150, TimeUnit.SECONDS)
             .build();
@@ -121,6 +122,12 @@ public class Main {
             System.out.println("Could not read config");
             e.printStackTrace();
             return;
+        }
+
+        if (CONFIG.cosmosInternalKeys != null && !CONFIG.cosmosInternalKeys.isEmpty()) {
+            CosmosInternalKeys = CONFIG.cosmosInternalKeys;
+        } else {
+            CosmosInternalKeys = DEFAULT_COSMOS_INTERNAL_KEYS;
         }
 
         String cert = System.getenv("CERT_FILE");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cosmos internal keys are now configurable at runtime through the configuration system, with predefined defaults applied as a fallback when custom values are not specified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->