### PR TITLE
Add full-document-key opt to mongo connector.

### DIFF
--- a/connectors/cosmos/conn.go
+++ b/connectors/cosmos/conn.go
@@ -279,6 +279,7 @@ func convertChangeStreamEventToUpdate(change bson.M) (*adiomv1.Update, error) {
 			Id: []*adiomv1.BsonValue{{
 				Data: idVal,
 				Type: uint32(idType),
+				Name: "_id",
 			}},
 			Type: adiomv1.UpdateType_UPDATE_TYPE_DELETE,
 		}, nil
@@ -299,6 +300,7 @@ func convertChangeStreamEventToUpdate(change bson.M) (*adiomv1.Update, error) {
 		Id: []*adiomv1.BsonValue{{
 			Data: idVal,
 			Type: uint32(idType),
+			Name: "_id",
 		}},
 		Type: adiomv1.UpdateType_UPDATE_TYPE_UPDATE,
 		Data: fullDocumentRaw,
@@ -333,6 +335,7 @@ func checkForDeletes(ctx context.Context, client *mongo.Client, witnessClient *m
 				Id: []*adiomv1.BsonValue{{
 					Data: idVal,
 					Type: uint32(idType),
+					Name: "_id",
 				}},
 				Type: adiomv1.UpdateType_UPDATE_TYPE_DELETE,
 			})

--- a/internal/app/options/connectorflags.go
+++ b/internal/app/options/connectorflags.go
@@ -760,6 +760,11 @@ func MongoFlags(settings *mongo.ConnectorSettings) []cli.Flag {
 			Name:        "skip-batch-overwrite",
 			Destination: &settings.SkipBatchOverwrite,
 		}),
+		altsrc.NewBoolFlag(&cli.BoolFlag{
+			Name:        "full-document-key",
+			Usage:       "uses the full document key instead of just _id (except for batch overwrites)",
+			Destination: &settings.FullDocumentKey,
+		}),
 		altsrc.NewDurationFlag(&cli.DurationFlag{
 			Name:        "server-timeout",
 			Required:    false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --full-document-key CLI flag for the MongoDB connector.
  * MongoDB connector can derive composite document IDs from full document keys and include full document data in change-stream updates when enabled.

* **Bug Fixes / Improvements**
  * CosmosDB change-stream updates now include the _id field in produced identifiers for deletes/updates.
  * Reduced redundant update/write operations and improved change-stream processing reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->